### PR TITLE
Features/camera logs

### DIFF
--- a/customAssets/i18n/ca.json
+++ b/customAssets/i18n/ca.json
@@ -12,5 +12,10 @@
     "settings":"Settings",
     "logout":"Logout"
     },
+    "logs-selector": {
+        "title": "Veure Logs",
+        "send": "Enviar Logs",
+        "camera": "Logs de càmera"
+    },
     "":""
 }

--- a/customAssets/i18n/en.json
+++ b/customAssets/i18n/en.json
@@ -13,5 +13,10 @@
     "settings":"Settings",
     "logout":"Logout"
     },
+    "logs-selector": {
+        "title": "Veure Logs",
+        "send": "Enviar Logs",
+        "camera": "Logs de càmera"
+    },
     "":""
 }

--- a/customAssets/i18n/es.json
+++ b/customAssets/i18n/es.json
@@ -11,5 +11,10 @@
     "faqs":"FAQs",
     "settings":"Ajustes",
     "logout":"Logout"},
+    "logs-selector": {
+        "title": "Veure Logs",
+        "send": "Enviar Logs",
+        "camera": "Logs de càmera"
+    },
     "":""
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7208,10 +7208,11 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -7221,7 +7222,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -7453,6 +7454,7 @@
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
       "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8587,6 +8589,7 @@
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
       "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
         "es-errors": "^1.3.0",
@@ -8991,6 +8994,7 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
       "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.4"
       },
@@ -9003,6 +9007,7 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -9414,6 +9419,7 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9494,37 +9500,38 @@
       "dev": true
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -9549,18 +9556,30 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
-    "node_modules/express/node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+    "node_modules/express/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express/node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -9575,13 +9594,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/express/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -9889,6 +9910,7 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -9983,6 +10005,7 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
       "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2",
@@ -10113,6 +10136,7 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -10152,6 +10176,7 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
       },
@@ -10164,6 +10189,7 @@
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -10176,6 +10202,7 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -13997,10 +14024,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -14844,6 +14875,7 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -15348,10 +15380,11 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
-      "dev": true
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "5.0.0",
@@ -15943,12 +15976,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -16625,10 +16659,11 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
@@ -16653,6 +16688,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -16661,13 +16697,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -16679,13 +16717,15 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/send/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -16769,18 +16809,29 @@
       "dev": true
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-blocking": {
@@ -16793,6 +16844,7 @@
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
       "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
         "es-errors": "^1.3.0",
@@ -16858,6 +16910,7 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { AutoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
+import { logsEnabledGuard } from './guards/logs-enabled.guard';
 
 export const routes: Routes = [
   {
@@ -53,19 +54,26 @@ export const routes: Routes = [
       },
       {
         path: 'logs',
+        canActivate:[AutoLoginPartialRoutesGuard, logsEnabledGuard],
         loadComponent: () =>
           import('./pages/logs/logs.page').then(
             (m) => m.LogsPage
           ),
-      },
-      //TODO include as logs children
-      {
-        path: 'logs/camera',
-        canActivate: [AutoLoginPartialRoutesGuard],
-        loadComponent: () =>
-          import('./pages/logs/camera-logs/camera-logs.page').then(
-            (m) => m.CameraLogsPage
-            ),
+          children:[
+            {
+              path:'',
+              loadComponent: () =>
+                import('./pages/logs/logs/logs.component').then(
+                  (m) => m.LogsComponent
+                )
+            },
+            {
+            path: 'camera',
+            loadComponent: () =>
+              import('./pages/logs/camera-logs/camera-logs.page').then(
+                (m) => m.CameraLogsPage
+                )
+          }]
       },
       {
         path: 'vc-selector',

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -38,13 +38,11 @@ export const routes: Routes = [
       {
         path: 'language-selector',
         canActivate: [AutoLoginPartialRoutesGuard],
-
         loadComponent: () =>
           import('./pages/language-selector/language-selector.page').then(
             (m) => m.LanguageSelectorPage
           ),
       },
-
       {
         path: 'camera-selector',
         canActivate: [AutoLoginPartialRoutesGuard],
@@ -53,7 +51,22 @@ export const routes: Routes = [
             (m) => m.CameraSelectorPage
           ),
       },
-
+      {
+        path: 'logs',
+        loadComponent: () =>
+          import('./pages/logs/logs.page').then(
+            (m) => m.LogsPage
+          ),
+      },
+      //TODO include as logs children
+      {
+        path: 'logs/camera',
+        canActivate: [AutoLoginPartialRoutesGuard],
+        loadComponent: () =>
+          import('./pages/logs/camera-logs/camera-logs.page').then(
+            (m) => m.CameraLogsPage
+            ),
+      },
       {
         path: 'vc-selector',
         canActivate: [AutoLoginPartialRoutesGuard],

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -7,5 +7,6 @@
     [formats]="allowedFormats"
     (camerasFound)="onCamerasFound($event)"
     (scanSuccess)="onCodeResult($event)"
-    (scanError)="scanError($event)"
+    (scanError)="scanError($event)" 
+    (scanFailure)="scanError($event)"
   ></zxing-scanner>

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -7,6 +7,6 @@
     [formats]="allowedFormats"
     (camerasFound)="onCamerasFound($event)"
     (scanSuccess)="onCodeResult($event)"
-    (scanError)="scanError($event)" 
-    (scanFailure)="scanError($event)"
+    (scanError)="scanError($event, 'error')" 
+    (scanFailure)="scanError($event, 'failure')"
   ></zxing-scanner>

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -7,6 +7,7 @@
     [formats]="allowedFormats"
     (camerasFound)="onCamerasFound($event)"
     (scanSuccess)="onCodeResult($event)"
-    (scanError)="scanError($event, 'error')" 
+    (scanError)="onScanError($event)" 
+    (scanFailure)="onScanFailure($event)"
     ></zxing-scanner>
     <!-- (scanFailure)="scanError($event, 'failure')" -->

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -8,5 +8,5 @@
     (camerasFound)="onCamerasFound($event)"
     (scanSuccess)="onCodeResult($event)"
     (scanError)="scanError($event, 'error')" 
-    (scanFailure)="scanError($event, 'failure')"
-  ></zxing-scanner>
+    ></zxing-scanner>
+    <!-- (scanFailure)="scanError($event, 'failure')" -->

--- a/src/app/components/barcode-scanner/barcode-scanner.component.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.ts
@@ -16,6 +16,7 @@ import {
   map,
   shareReplay,
 } from 'rxjs';
+import { CameraLogType } from 'src/app/interfaces/camera-log';
 import { CameraService } from 'src/app/services/camera.service';
 
 @Component({
@@ -81,9 +82,10 @@ export class BarcodeScannerComponent implements OnInit {
     this.availableDevices.emit(devices);
   }
 
-  public scanError(error: Error|undefined) {
-    console.error(error);
-    this.cameraLogsService.addCameraLog(error);
+  public scanError(error: Error|undefined, exceptionType: CameraLogType) {
+    console.error("Error when scanning from barcode-scanner: " + error );
+    console.error("Error type: " + exceptionType);
+    this.cameraLogsService.addCameraLog(error, exceptionType);
   }
 
 }

--- a/src/app/components/barcode-scanner/barcode-scanner.component.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.ts
@@ -1,3 +1,4 @@
+import { CameraLogsService } from './../../services/camera-logs.service';
 import { CommonModule } from '@angular/common';
 import {
   Component,
@@ -52,7 +53,7 @@ export class BarcodeScannerComponent implements OnInit {
     );
 
   public scanSuccess$ = new BehaviorSubject<string>('');
-  public constructor(private cameraService: CameraService) {}
+  public constructor(private cameraService: CameraService, private cameraLogsService: CameraLogsService) {}
   public ngOnInit(): void {
     setTimeout(() => {
       this.cameraService.updateCamera();
@@ -80,7 +81,9 @@ export class BarcodeScannerComponent implements OnInit {
     this.availableDevices.emit(devices);
   }
 
-  public scanError(error: Error) {
+  public scanError(error: Error|undefined) {
     console.error(error);
+    this.cameraLogsService.addCameraLog(error);
   }
+
 }

--- a/src/app/guards/logs-enabled.guard.spec.ts
+++ b/src/app/guards/logs-enabled.guard.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { CanActivateFn } from '@angular/router';
+
+import { logsEnabledGuard } from './logs-enabled.guard';
+
+describe('logsEnabledGuard', () => {
+  const executeGuard: CanActivateFn = (...guardParameters) => 
+      TestBed.runInInjectionContext(() => logsEnabledGuard(...guardParameters));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(executeGuard).toBeTruthy();
+  });
+});

--- a/src/app/guards/logs-enabled.guard.ts
+++ b/src/app/guards/logs-enabled.guard.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { environment } from 'src/environments/environment';
+
+export const logsEnabledGuard: CanActivateFn = (route, state) => {
+  const router = inject(Router);
+  if(environment.logs_enabled){
+    return true;
+  }
+  router.navigate(['/settings']);
+  return false;
+};

--- a/src/app/interfaces/camera-log.ts
+++ b/src/app/interfaces/camera-log.ts
@@ -1,5 +1,9 @@
+export type CameraLogType = 'error' | 'failure';
+
 export interface CameraLog{
     id:string;
+    type:CameraLogType,
+    stack:string,
     message:string;
     date:Date;
 }

--- a/src/app/interfaces/camera-log.ts
+++ b/src/app/interfaces/camera-log.ts
@@ -1,9 +1,12 @@
-export type CameraLogType = 'error' | 'failure';
+export type CameraLogType = 'scanError' | 'scanFailure' | 'noMediaError' | 'httpError' | 'fetchError' | 'undefinedError';
 
 export interface CameraLog{
-    id:string;
     type:CameraLogType,
-    stack:string,
     message:string;
-    date:Date;
+    date:string;
+}
+
+export interface LogsMailContent{
+    subject:string,
+    body:string
 }

--- a/src/app/interfaces/camera-log.ts
+++ b/src/app/interfaces/camera-log.ts
@@ -1,0 +1,5 @@
+export interface CameraLog{
+    id:string;
+    message:string;
+    date:Date;
+}

--- a/src/app/interfaces/global.d.ts
+++ b/src/app/interfaces/global.d.ts
@@ -19,6 +19,7 @@ interface Window {
       ebsi_did_uri?: string;
       cbor_uri?: string;
       websocket_uri?: string;
+      logs_enabled?: boolean
     };
   }
   

--- a/src/app/pages/logs/camera-logs/camera-logs.page.html
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.html
@@ -1,13 +1,8 @@
 <ion-content [fullscreen]="true" class="background-content">
   <ion-list class="settings-list">
-    @for(log of cameraLogs$(); track $index){
+    @for(log of cameraLogs; track $index){
       <ion-item>
         <ion-grid>
-          <ion-row>
-            <ion-col>
-              <ion-text>Log ID: {{log.id}}</ion-text>
-            </ion-col>
-          </ion-row>
           <ion-row>
             <ion-col>
               <ion-text>Log message: {{log.message}}</ion-text>
@@ -15,7 +10,7 @@
           </ion-row>
           <ion-row>
             <ion-col>
-              <ion-text>Log date: {{log.date | date: 'short'}}</ion-text>
+              <ion-text>Date: {{log.date | date: 'short'}}</ion-text>
             </ion-col>
           </ion-row>
         </ion-grid>

--- a/src/app/pages/logs/camera-logs/camera-logs.page.html
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.html
@@ -1,0 +1,31 @@
+<ion-content [fullscreen]="true" class="background-content">
+  <ion-list class="settings-list">
+    @for(log of cameraLogs$(); track $index){
+      <ion-item>
+        <ion-grid>
+          <ion-row>
+            <ion-col>
+              <ion-text>Log ID: {{log.id}}</ion-text>
+            </ion-col>
+          </ion-row>
+          <ion-row>
+            <ion-col>
+              <ion-text>Log message: {{log.message}}</ion-text>
+            </ion-col>
+          </ion-row>
+          <ion-row>
+            <ion-col>
+              <ion-text>Log date: {{log.date | date: 'short'}}</ion-text>
+            </ion-col>
+          </ion-row>
+        </ion-grid>
+      </ion-item>
+      <ion-item-divider></ion-item-divider>
+    }@empty {
+      <div>No camera logs to show.</div>
+    }
+  </ion-list>
+</ion-content>
+
+     
+ 

--- a/src/app/pages/logs/camera-logs/camera-logs.page.scss
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.scss
@@ -7,7 +7,3 @@
 .settings-icon {
     margin-right: 1rem;
 }
-
-ion-button{
-    margin-left:16px;
-}

--- a/src/app/pages/logs/camera-logs/camera-logs.page.spec.ts
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CameraLogsPage } from './camera-logs.page';
+
+describe('ViewLogsComponent', () => {
+  let component: CameraLogsPage;
+  let fixture: ComponentFixture<CameraLogsPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [CameraLogsPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CameraLogsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/logs/camera-logs/camera-logs.page.ts
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.ts
@@ -1,0 +1,32 @@
+import { CameraLog } from 'src/app/interfaces/camera-log';
+import { CameraLogsService } from '../../../services/camera-logs.service';
+import { Component, inject, OnInit, Signal, signal } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { DatePipe } from '@angular/common';
+
+@Component({
+  selector: 'app-view-logs',
+  templateUrl: './camera-logs.page.html',
+  styleUrls: ['./camera-logs.page.scss'],
+  standalone: true,
+  imports:[ IonicModule, DatePipe]
+})
+export class CameraLogsPage implements OnInit {
+  private cameraLogsService = inject(CameraLogsService);
+
+  private cameraLogs = this.cameraLogsService.cameraLogs$;
+
+  get cameraLogs$(): Signal<CameraLog[] | undefined>{
+    return this.cameraLogs;
+  }
+
+  constructor() { }
+
+  ngOnInit() {
+    const dummyError = new Error('DummyError added from View-camer-logs.page');
+    //TODO remove addCamera (dummy)
+    this.cameraLogsService.addCameraLog(dummyError);
+    this.cameraLogsService.fetchCameraLogs();
+  }
+
+}

--- a/src/app/pages/logs/camera-logs/camera-logs.page.ts
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.ts
@@ -1,6 +1,6 @@
 import { CameraLog } from 'src/app/interfaces/camera-log';
 import { CameraLogsService } from '../../../services/camera-logs.service';
-import { Component, inject, OnInit, Signal, signal } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { DatePipe } from '@angular/common';
 
@@ -14,22 +14,15 @@ import { DatePipe } from '@angular/common';
 export class CameraLogsPage implements OnInit {
   private cameraLogsService = inject(CameraLogsService);
 
-  private cameraLogs = this.cameraLogsService.cameraLogs$;
+  public cameraLogs:CameraLog[] = [];
 
-  get cameraLogs$(): Signal<CameraLog[] | undefined>{
-    return this.cameraLogs;
+
+  constructor() { 
   }
 
-  constructor() { }
-
   async ngOnInit() {
-    //TODO remove addCamera (dummy)
-    // const dummyError = new Error('DummyError added from View-camer-logs.page');
-    // await this.cameraLogsService.addCameraLog(dummyError, 'error');
-    // await this.cameraLogsService.addCameraLog(new Error('DummyError2 added from View-camer-logs.page'), 'error');
-    // await this.cameraLogsService.addCameraLog(new Error('DummyError3 added from View-camer-logs.page'), 'error');
-
-    this.cameraLogsService.fetchCameraLogs();
+    const logs = await this.cameraLogsService.getCameraLogs();
+    this.cameraLogs = logs;
   }
 
 }

--- a/src/app/pages/logs/camera-logs/camera-logs.page.ts
+++ b/src/app/pages/logs/camera-logs/camera-logs.page.ts
@@ -22,10 +22,13 @@ export class CameraLogsPage implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {
-    const dummyError = new Error('DummyError added from View-camer-logs.page');
+  async ngOnInit() {
     //TODO remove addCamera (dummy)
-    this.cameraLogsService.addCameraLog(dummyError);
+    // const dummyError = new Error('DummyError added from View-camer-logs.page');
+    // await this.cameraLogsService.addCameraLog(dummyError, 'error');
+    // await this.cameraLogsService.addCameraLog(new Error('DummyError2 added from View-camer-logs.page'), 'error');
+    // await this.cameraLogsService.addCameraLog(new Error('DummyError3 added from View-camer-logs.page'), 'error');
+
     this.cameraLogsService.fetchCameraLogs();
   }
 

--- a/src/app/pages/logs/logs.page.html
+++ b/src/app/pages/logs/logs.page.html
@@ -1,10 +1,3 @@
-<ion-content [fullscreen]="true" class="background-content">
-  <b class="pages_titles">
-    {{"logs-selector.title"|translate}}
-  </b>
-  <ion-list class="logs-list">
-      <ion-item [routerLink]="['/tabs/logs/camera']">
-        <ion-icon color="grey" name="camera" class="logs-icon"></ion-icon><ion-text>{{"logs-selector.camera"|translate}}</ion-text>
-      </ion-item>
-  </ion-list>
+<ion-content>
+    <router-outlet/>
 </ion-content>

--- a/src/app/pages/logs/logs.page.html
+++ b/src/app/pages/logs/logs.page.html
@@ -1,0 +1,10 @@
+<ion-content [fullscreen]="true" class="background-content">
+  <b class="pages_titles">
+    {{"logs-selector.title"|translate}}
+  </b>
+  <ion-list class="logs-list">
+      <ion-item [routerLink]="['/tabs/logs/camera']">
+        <ion-icon color="grey" name="camera" class="logs-icon"></ion-icon><ion-text>{{"logs-selector.camera"|translate}}</ion-text>
+      </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/pages/logs/logs.page.scss
+++ b/src/app/pages/logs/logs.page.scss
@@ -1,13 +1,9 @@
-.settings-list {
+.logs-list {
     margin: 20px;
     --ion-item-background: white;
     --ion-item-color: grey;
 }
 
-.settings-icon {
+.logs-icon {
     margin-right: 1rem;
-}
-
-ion-button{
-    margin-left:16px;
 }

--- a/src/app/pages/logs/logs.page.spec.ts
+++ b/src/app/pages/logs/logs.page.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LogsPage } from './logs.page';
+
+describe('LogsPageComponent', () => {
+  let component: LogsPage;
+  let fixture: ComponentFixture<LogsPage>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [LogsPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogsPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/logs/logs.page.ts
+++ b/src/app/pages/logs/logs.page.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { RouterModule } from '@angular/router';
+import { RouterOutlet } from '@angular/router';
 import { IonicModule } from '@ionic/angular';
-import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-logs-page',
@@ -9,9 +8,8 @@ import { TranslateModule } from '@ngx-translate/core';
   styleUrls: ['./logs.page.scss'],
   standalone: true,
   imports:[
-    IonicModule,
-    RouterModule,
-    TranslateModule
+    RouterOutlet,
+    IonicModule
   ]
 })
 export class LogsPage  implements OnInit {

--- a/src/app/pages/logs/logs.page.ts
+++ b/src/app/pages/logs/logs.page.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-logs-page',
+  templateUrl: './logs.page.html',
+  styleUrls: ['./logs.page.scss'],
+  standalone: true,
+  imports:[
+    IonicModule,
+    RouterModule,
+    TranslateModule
+  ]
+})
+export class LogsPage  implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/pages/logs/logs.page.ts
+++ b/src/app/pages/logs/logs.page.ts
@@ -16,8 +16,10 @@ import { TranslateModule } from '@ngx-translate/core';
 })
 export class LogsPage  implements OnInit {
 
-  constructor() { }
+  constructor() {
+   }
 
-  ngOnInit() {}
+  ngOnInit() {
+  }
 
 }

--- a/src/app/pages/logs/logs/logs.component.html
+++ b/src/app/pages/logs/logs/logs.component.html
@@ -1,0 +1,10 @@
+<ion-content [fullscreen]="true" class="background-content">
+  <b class="pages_titles">
+    {{"logs-selector.title"|translate}}
+  </b>
+  <ion-list class="logs-list">
+      <ion-item [routerLink]="['/tabs/logs/camera']">
+        <ion-icon color="grey" name="camera" class="logs-icon"></ion-icon><ion-text>{{"logs-selector.camera"|translate}}</ion-text>
+      </ion-item>
+  </ion-list>
+</ion-content>

--- a/src/app/pages/logs/logs/logs.component.spec.ts
+++ b/src/app/pages/logs/logs/logs.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { LogsComponent } from './logs.component';
+
+describe('LogsComponent', () => {
+  let component: LogsComponent;
+  let fixture: ComponentFixture<LogsComponent>;
+
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [LogsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LogsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }));
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/logs/logs/logs.component.ts
+++ b/src/app/pages/logs/logs/logs.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+
+@Component({
+  selector: 'app-logs',
+  templateUrl: './logs.component.html',
+  styleUrls: ['./logs.component.scss'],
+  standalone: true,
+  imports:[
+    IonicModule,
+    RouterModule,
+    TranslateModule
+  ]
+})
+export class LogsComponent  implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {}
+
+}

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -10,7 +10,7 @@
         <ion-icon color="grey" name="globe-outline"  class="settings-icon"></ion-icon>{{"language-selector.title"|translate}}
       </ion-item>
       <ion-item [routerLink]="['/tabs/logs']"> 
-        <ion-icon color="grey" name="globe-outline"  class="settings-icon"></ion-icon>{{"logs-selector.title"|translate}}
+        <ion-icon color="grey" name="document-text-outline"  class="settings-icon"></ion-icon>{{"logs-selector.title"|translate}}
       </ion-item>
       <ion-button (click)="sendCameraLogs()">{{"logs-selector.send"|translate}}</ion-button>
   </ion-list>

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -4,16 +4,15 @@
   </b>
   <ion-list class="settings-list">
       <ion-item [routerLink]="['/tabs/camera-selector']">
-       
         <ion-icon color="grey" name="camera" class="settings-icon"></ion-icon><ion-text>{{"camera-selector.title"|translate}}</ion-text>
       </ion-item>
       <ion-item [routerLink]="['/tabs/language-selector']">
-       
         <ion-icon color="grey" name="globe-outline"  class="settings-icon"></ion-icon>{{"language-selector.title"|translate}}
       </ion-item>
-
-
-
+      <ion-item [routerLink]="['/tabs/logs']"> 
+        <ion-icon color="grey" name="globe-outline"  class="settings-icon"></ion-icon>{{"logs-selector.title"|translate}}
+      </ion-item>
+      <ion-button (click)="sendCameraLogs()">{{"logs-selector.send"|translate}}</ion-button>
   </ion-list>
 
 

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -9,10 +9,12 @@
       <ion-item [routerLink]="['/tabs/language-selector']">
         <ion-icon color="grey" name="globe-outline"  class="settings-icon"></ion-icon>{{"language-selector.title"|translate}}
       </ion-item>
-      <ion-item [routerLink]="['/tabs/logs']"> 
-        <ion-icon color="grey" name="document-text-outline"  class="settings-icon"></ion-icon>{{"logs-selector.title"|translate}}
-      </ion-item>
-      <ion-button (click)="sendCameraLogs()">{{"logs-selector.send"|translate}}</ion-button>
+      @if(featureLogsEnabled){
+        <ion-item [routerLink]="['/tabs/logs']"> 
+          <ion-icon color="grey" name="document-text-outline"  class="settings-icon"></ion-icon>{{"logs-selector.title"|translate}}
+        </ion-item>
+        <ion-button (click)="sendCameraLogs()">{{"logs-selector.send"|translate}}</ion-button>
+      } 
   </ion-list>
 
 

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -3,9 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 import { Router, RouterModule } from '@angular/router';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DataService } from 'src/app/services/data.service';
-import { CameraService } from 'src/app/services/camera.service';
 import { CameraLogsService } from 'src/app/services/camera-logs.service';
 
 @Component({
@@ -29,8 +28,10 @@ export class SettingsPage {
   public constructor(
     private router: Router,
     private dataService: DataService,
-    private cameraLogsService: CameraLogsService
-  ) {}
+    private cameraLogsService: CameraLogsService,
+    private translate: TranslateService
+  ) {
+  }
 
   public goHomeWithEBSI() {
     this.dataService.getDid().subscribe({
@@ -46,7 +47,16 @@ export class SettingsPage {
   public toggleAlert() {
     this.isAlertOpen = !this.isAlertOpen;
   }
-  public sendCameraLogs(){
-    this.cameraLogsService.sendCameraLogs();
-  }
+
+  public async sendCameraLogs() {
+    this.translate.get('mailto_permission_alert').subscribe(async (translatedMsg: string) => {
+      try {
+        alert(translatedMsg)
+        await this.cameraLogsService.fetchCameraLogs();
+        this.cameraLogsService.sendCameraLogs();
+      } catch (error) {
+        console.error('Error sending camera logs:', error);
+      }
+  });
+}
 }

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -6,6 +6,7 @@ import { Router, RouterModule } from '@angular/router';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { DataService } from 'src/app/services/data.service';
 import { CameraLogsService } from 'src/app/services/camera-logs.service';
+import { environment } from 'src/environments/environment';
 
 @Component({
   selector: 'app-settings',
@@ -24,6 +25,7 @@ import { CameraLogsService } from 'src/app/services/camera-logs.service';
 export class SettingsPage {
   public userName = '';
   public isAlertOpen = false;
+  public featureLogsEnabled = environment.logs_enabled;
 
   public constructor(
     private router: Router,

--- a/src/app/pages/settings/settings.page.ts
+++ b/src/app/pages/settings/settings.page.ts
@@ -5,6 +5,8 @@ import { IonicModule } from '@ionic/angular';
 import { Router, RouterModule } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { DataService } from 'src/app/services/data.service';
+import { CameraService } from 'src/app/services/camera.service';
+import { CameraLogsService } from 'src/app/services/camera-logs.service';
 
 @Component({
   selector: 'app-settings',
@@ -26,7 +28,8 @@ export class SettingsPage {
 
   public constructor(
     private router: Router,
-    private dataService: DataService
+    private dataService: DataService,
+    private cameraLogsService: CameraLogsService
   ) {}
 
   public goHomeWithEBSI() {
@@ -42,5 +45,8 @@ export class SettingsPage {
   }
   public toggleAlert() {
     this.isAlertOpen = !this.isAlertOpen;
+  }
+  public sendCameraLogs(){
+    this.cameraLogsService.sendCameraLogs();
   }
 }

--- a/src/app/pages/tabs/tabs.page.html
+++ b/src/app/pages/tabs/tabs.page.html
@@ -1,17 +1,17 @@
 <ion-tabs #appTabs>
 
   <ion-tab-bar slot="bottom">
-    <ion-tab-button tab="home" [routerLink]="['/tabs/home']" routerDirection="root">
+    <ion-tab-button tab="home" [routerLink]="['./home']" routerDirection="root">
       <ion-icon aria-hidden="true" name="home"></ion-icon>
       <ion-label>{{"menu.home"|translate}}</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="credentials" [routerLink]="['/tabs/credentials']" routerDirection="root">
+    <ion-tab-button tab="credentials" [routerLink]="['./credentials']" routerDirection="root">
       <ion-icon aria-hidden="true" name="wallet"></ion-icon>
       <ion-label>{{"menu.credentials"|translate}}</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="settings" [routerLink]="['/tabs/settings']" routerDirection="root">
+    <ion-tab-button tab="settings" [routerLink]="['./settings']" routerDirection="root">
       <ion-icon aria-hidden="true" name="cog"></ion-icon>
       <ion-label>{{"menu.settings"|translate}}</ion-label>
     </ion-tab-button>

--- a/src/app/services/camera-logs.service.spec.ts
+++ b/src/app/services/camera-logs.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CameraLogsService } from './camera-logs.service';
+
+describe('CameraLogsService', () => {
+  let service: CameraLogsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CameraLogsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/camera-logs.service.ts
+++ b/src/app/services/camera-logs.service.ts
@@ -1,0 +1,71 @@
+import { inject, Injectable, Signal, signal } from '@angular/core';
+import { CameraLog } from '../interfaces/camera-log';
+import { HttpClient } from '@angular/common/http';
+import { distinctUntilChanged, Observable, tap } from 'rxjs';
+import { StorageService } from './storage.service';
+
+export const dummyCameraLogs:CameraLog[] = [
+  {
+  id:'1',
+  message:'log 1',
+  date: new Date()
+  },
+  {
+  id:'2',
+  message:'log 2',
+  date: new Date()
+  },
+];
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CameraLogsService {
+  private http = inject(HttpClient);
+  private storageService = inject(StorageService);
+
+  private cameraLogs = signal<CameraLog[]|undefined>([]);
+
+  get cameraLogs$(): Signal<CameraLog[]|undefined>{
+    return this.cameraLogs.asReadonly();
+  }
+
+  public setCameraLogs(logs: CameraLog[]|undefined): void{
+    const newLogs = logs !== undefined ? [...logs] : undefined;
+    this.cameraLogs.set(newLogs);
+  }
+
+  public async addCameraLog(log: Error|undefined):Promise<void> {
+    // Setup Log object
+    let message='undefined error';
+    if(log?.message){
+      message=log.message;
+    }
+
+    //store Log object and update
+      if(this.cameraLogs$){ //TODO remove dummies
+        await this.storageService.set('CAMERA_LOGS', dummyCameraLogs[0]);
+        this.cameraLogs.set([...this.cameraLogs$()!, dummyCameraLogs[0]]);
+        await this.storageService.set('CAMERA_LOGS', dummyCameraLogs[1]);
+        this.cameraLogs.set([...this.cameraLogs$()!, dummyCameraLogs[1]]);
+
+        await this.storageService.set('CAMERA_LOGS', log);
+      }
+  }
+
+  public async fetchCameraLogs():Promise<void> {
+    const items = await this.storageService.getAll();
+    const cameraLogs = items;
+  }
+
+   //TODO
+   public sendCameraLogs(): Observable<CameraLog[]|undefined>{
+    console.log("sendCameraLogs function executed");
+    alert("Send camera logs executed (pending implementation)");
+    return this.http.post<CameraLog[]|undefined>('', {});
+  }
+
+  constructor() {
+  }
+
+}

--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -11,8 +11,6 @@ export class StorageService {
     this.init();
   }
 
-
-
   public async set(llave: string, value: unknown) {
     await this._storage?.set(llave, value);
   }
@@ -24,6 +22,8 @@ export class StorageService {
       const val = await this._storage?.get(i.toString());
       items.push(val ?? '');
     }
+    //!
+    console.log(items);
     return items;
   }
 

--- a/src/assets/env.js
+++ b/src/assets/env.js
@@ -19,6 +19,6 @@
   window["env"]["users_uri"] = '/api/v2/users';
   window["env"]["ebsi_did_uri"] = '/api/v2/ebsi-did';
   window["env"]["cbor_uri"] = '/api/v2/vp/cbor';
-
+  window["env"]["logs_enabled"] = "false"
 
 })(this);

--- a/src/assets/env.template.js
+++ b/src/assets/env.template.js
@@ -19,5 +19,5 @@
   window["env"]["users_uri"] = "${WALLET_API_USERS_PATH}";
   window["env"]["ebsi_did_uri"] = "${WALLET_API_EBSI_PATH}";
   window["env"]["cbor_uri"] = "${WALLET_API_CBOR_PATH}";
-
+  window["env"]["logs_enabled"] = "${LOGS_ENABLED}"
 })(this);

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -73,6 +73,9 @@
         "send": "Enviar Logs",
         "camera": "Logs de càmera"
     },
+    "send-logs": {
+        "mailto_permission_alert": "Assegureu-vos que teniu els permisos necessaris per enviar correus electrònics amb la vostra aplicació de correu predeterminada. Si el servei de correu no s'obre, probablement és a causa de restriccions de permisos."
+    },
     "ebsi": {
       "title": "EBSI"
     },

--- a/src/assets/i18n/ca.json
+++ b/src/assets/i18n/ca.json
@@ -68,6 +68,11 @@
     "language-selector":{
         "title":"Selector d'idioma"
     },
+    "logs-selector": {
+        "title": "Veure Logs",
+        "send": "Enviar Logs",
+        "camera": "Logs de càmera"
+    },
     "ebsi": {
       "title": "EBSI"
     },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -73,6 +73,7 @@
         "send": "Send Logs",
         "camera": "Camera logs"
     },
+    "mailto_permission_alert": "Please ensure that you have the necessary permissions to send emails using your default mail application. If the mail service does not open, it is likely due to permission restrictions.",
     "ebsi": {
       "title": "EBSI"
     },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -68,6 +68,11 @@
     "language-selector":{
         "title":"Select language"
     },
+    "logs-selector": {
+        "title": "View logs",
+        "send": "Send Logs",
+        "camera": "Camera logs"
+    },
     "ebsi": {
       "title": "EBSI"
     },

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -70,6 +70,11 @@
     "language-selector":{
         "title":"Selector de idioma"
     },
+    "logs-selector": {
+        "title": "Ver logs",
+        "send": "Enviar Logs",
+        "camera": "Logs de cámara"
+    },
     "login":{
         "title":"Login",
         "login":"Login",

--- a/src/environments/environment.customdev.ts
+++ b/src/environments/environment.customdev.ts
@@ -20,5 +20,6 @@ export const environment = {
     ebsi_did_uri: window["env"]["ebsi_did_uri"] || '/api/v2/ebsi-did',
     cbor: window["env"]["cbor_uri"] || '/api/v2/vp/cbor',
   },
-  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin'
+  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
+  LOGS_EMAIL: "domesupport@in2.es"
 };

--- a/src/environments/environment.customdev.ts
+++ b/src/environments/environment.customdev.ts
@@ -21,5 +21,6 @@ export const environment = {
     cbor: window["env"]["cbor_uri"] || '/api/v2/vp/cbor',
   },
   websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
-  LOGS_EMAIL: "domesupport@in2.es"
+  LOGS_EMAIL: "domesupport@in2.es",
+  logs_enabled: window["env"]["logs_enabled"] || false
 };

--- a/src/environments/environment.customprod.ts
+++ b/src/environments/environment.customprod.ts
@@ -22,5 +22,6 @@ export const environment = {
 
   },
   websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
-  LOGS_EMAIL: "domesupport@in2.es"
+  LOGS_EMAIL: "domesupport@in2.es",
+  logs_enabled: window["env"]["logs_enabled"] || true
 };

--- a/src/environments/environment.customprod.ts
+++ b/src/environments/environment.customprod.ts
@@ -21,5 +21,6 @@ export const environment = {
     cbor: window["env"]["cbor_uri"] || '/api/v2/vp/cbor'
 
   },
-  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin'
+  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
+  LOGS_EMAIL: "domesupport@in2.es"
 };

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -22,5 +22,6 @@ export const environment = {
 
   },
   websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
-  LOGS_EMAIL: "domesupport@in2.es"
+  LOGS_EMAIL: "domesupport@in2.es",
+  logs_enabled: window["env"]["logs_enabled"] || true
 };

--- a/src/environments/environment.dev.ts
+++ b/src/environments/environment.dev.ts
@@ -21,5 +21,6 @@ export const environment = {
     cbor: window["env"]["cbor_uri"] || '/api/v2/vp/cbor'
 
   },
-  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin'
+  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
+  LOGS_EMAIL: "domesupport@in2.es"
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -21,5 +21,6 @@ export const environment = {
     cbor: window["env"]["cbor_uri"] || '/api/v2/vp/cbor'
 
   },
-  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin'
+  websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
+  LOGS_EMAIL: "domesupport@in2.es"
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -22,5 +22,6 @@ export const environment = {
 
   },
   websocket_uri: window["env"]["websocket_uri"] || '/api/v2/pin',
-  LOGS_EMAIL: "domesupport@in2.es"
+  LOGS_EMAIL: "domesupport@in2.es",
+  logs_enabled: window["env"]["logs_enabled"] || false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -20,6 +20,6 @@ export const environment = {
     ebsi_did_uri: '/api/v1/ebsi-did',
     cbor: '/api/v1/vp/cbor',
   },
-  websocket_uri: '/api/v1/pin'
-
+  websocket_uri: '/api/v1/pin',
+  LOGS_EMAIL: "domesupport@in2.es"
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -21,5 +21,6 @@ export const environment = {
     cbor: '/api/v1/vp/cbor',
   },
   websocket_uri: '/api/v1/pin',
-  LOGS_EMAIL: "domesupport@in2.es"
+  LOGS_EMAIL: "domesupport@in2.es",
+  logs_enabled: false
 };

--- a/src/global.scss
+++ b/src/global.scss
@@ -31,3 +31,8 @@
   font-family: 'Blinker-Regular';
   src: url('./assets/fonts/Blinker-Regular.ttf') format('truetype');
 }
+
+
+ion-item-divider:last-of-type{
+  display:none;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { enableProdMode, importProvidersFrom } from '@angular/core';
+import { enableProdMode, ErrorHandler, importProvidersFrom } from '@angular/core';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter } from '@angular/router';
 import { IonicModule, IonicRouteStrategy } from '@ionic/angular';
@@ -71,7 +71,7 @@ bootstrapApplication(AppComponent, {
       provide: HTTP_INTERCEPTORS,
       useClass: HttpErrorInterceptor,
       multi: true,
-    },
+    }
   ],
 });
 export function httpTranslateLoader(http: HttpClient) {


### PR DESCRIPTION
-Camera-related logs management: captures errors from the built-in error listeners from zxing-scanner (scanError, scanFailure) as well as from qr http requests and from the fetching/parsing from the storage. Other errors captured by zxing-scanner are intercepted though console.error. Stack-traces are not stored due to length limitations when sending (see below).
-Logs are stored through storage service (which uses Ionic storage --indexedDB).
-Logs are shown in Settings>View Logs>Camera logs
-Last logs are sent from Settings>Send logs through mailTo. Only 1400 characters, which is aprox. the minimum size allowed by local email services.
-Feature-flag conditioned (logs-enabled)

-Also it was added the deactivation of the camera when living barcode-scanner when credentials page is left.