### PR TITLE
Feature/deactivate camera

### DIFF
--- a/src/app/components/barcode-scanner/barcode-scanner.component.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.ts
@@ -62,7 +62,9 @@ export class BarcodeScannerComponent implements OnInit {
       takeUntilDestroyed()
     )
     .subscribe((event: NavigationEnd) => {
-      this.scanner.reset();
+      if (!event.urlAfterRedirects.startsWith('/tabs/credentials')) {
+        this.scanner.reset();
+      }
     });
   }
   public ngOnInit(): void {

--- a/src/app/pages/credentials/credentials.page.spec.ts
+++ b/src/app/pages/credentials/credentials.page.spec.ts
@@ -294,38 +294,31 @@ describe('CredentialsPage', () => {
   }));
 
 
-  // it('should untoggle scan and call detectChanges when navigation is outside /tabs/credentials', fakeAsync(() => {
-  //   const mockNavigationEndEvent = new NavigationEnd(42, '/tabs/credentials', '/new-url/tabs/other-section');
-  //   walletServiceSpy.getAllVCs.and.returnValue(of([])); //si no dona error
+  it('should untoggle scan and call detectChanges when navigation is outside /tabs/credentials', fakeAsync(() => {
+    const mockNavigationEndEvent = new NavigationEnd(42, '/tabs/credentials', '/new-url/tabs/other-section');
+    walletServiceSpy.getAllVCs.and.returnValue(of([]));
 
-  //   const untoggleScanSpy = spyOn(component, 'untoggleScan');
-  //   const detectChangesSpy = spyOn(component['cdr'], 'detectChanges');
+    const untoggleScanSpy = spyOn(component, 'untoggleScan');
+    const detectChangesSpy = spyOn(component['cdr'], 'detectChanges');
    
-  //   mockRouter.events.next(mockNavigationEndEvent);
+    mockRouter.events.next(mockNavigationEndEvent);
  
-  //   fixture.detectChanges();
-  //   // tick();
-  //   flush();
- 
-  //   expect(untoggleScanSpy).toHaveBeenCalled();
-  //   expect(detectChangesSpy).toHaveBeenCalled();
-  // }));
+    expect(untoggleScanSpy).toHaveBeenCalled();
+    expect(detectChangesSpy).toHaveBeenCalled();
+  }));
 
 
-  // it('should not untoggle scan if the destination starts with /tabs/credentials', fakeAsync(() => {
-  //   const mockNavigationEndEvent = new NavigationEnd(42, '/tabs/credentials', '/tabs/credentials/some-subroute');
-  //   walletServiceSpy.getAllVCs.and.returnValue(of([])); //si no dona error
-  //   const untoggleScanSpy = spyOn(component, 'untoggleScan');
-  //   const detectChangesSpy = spyOn(component['cdr'], 'detectChanges');
+  it('should not untoggle scan if the destination starts with /tabs/credentials', fakeAsync(() => {
+    const mockNavigationEndEvent = new NavigationEnd(42, '/tabs/credentials', '/tabs/credentials/some-subroute');
+    walletServiceSpy.getAllVCs.and.returnValue(of([])); //si no dona error
+    const untoggleScanSpy = spyOn(component, 'untoggleScan');
+    const detectChangesSpy = spyOn(component['cdr'], 'detectChanges');
    
-  //   spyOn(mockRouter.events, 'pipe').and.returnValue(of(mockNavigationEndEvent));
+    spyOn(mockRouter.events, 'pipe').and.returnValue(of(mockNavigationEndEvent));
  
-  //   fixture.detectChanges();
-  //   // tick();
-  //   flush();
  
-  //   expect(untoggleScanSpy).not.toHaveBeenCalled();
-  //   expect(detectChangesSpy).not.toHaveBeenCalled();
-  // }));
+    expect(untoggleScanSpy).not.toHaveBeenCalled();
+    expect(detectChangesSpy).not.toHaveBeenCalled();
+  }));
 
 });

--- a/src/app/pages/home/home.page.spec.ts
+++ b/src/app/pages/home/home.page.spec.ts
@@ -63,17 +63,14 @@ describe('HomePage', () => {
   });
 
   it('startScan should navigate with specific queryParams', async () => {
+    const audioStream:any = { getTracks: ()=>[] }; 
+    let promise = Promise.resolve(audioStream);
+    spyOn(navigator.mediaDevices, 'getUserMedia').and.returnValue(promise);
+
     const navigateSpy = spyOn(mockRouter, 'navigate');
     await component.startScan();
     expect(navigateSpy).toHaveBeenCalledWith(['/tabs/credentials/'], { queryParams: { toggleScan: true, from: 'home', show_qr: true } });
   });
-
-  // it('startScan should navigate with specific queryParams', fakeAsync(() => {
-  //   const navigateSpy = spyOn(mockRouter, 'navigate');
-  //   component.startScan();
-  //   tick();
-  //   expect(navigateSpy).toHaveBeenCalledWith(['/tabs/credentials/'], { queryParams: { toggleScan: true, from: 'home', show_qr: true } });
-  // }));
   
   
 

--- a/src/app/pages/home/home.page.spec.ts
+++ b/src/app/pages/home/home.page.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { RouterTestingModule } from '@angular/router/testing';
 import { TranslateModule } from '@ngx-translate/core';
@@ -6,13 +6,19 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { HomePage } from './home.page';
 import { BehaviorSubject } from 'rxjs';
 
+class MockRouter {
+  public navigate = (route:string|string[], opt?:{})=>'';
+}
+
 describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
-  let router: Router;
   let route: ActivatedRoute;
+  let mockRouter: MockRouter;
 
   beforeEach(async () => {
+    mockRouter = new MockRouter();
+
     await TestBed.configureTestingModule({
       imports: [
         IonicModule.forRoot(),
@@ -25,13 +31,12 @@ describe('HomePage', () => {
           useValue: {
             queryParams: new BehaviorSubject({ credential_offer_uri: 'someUri' })
           }
-        }
+        }, {provide:Router, useValue:mockRouter}
       ]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
-    router = TestBed.inject(Router);
     route = TestBed.inject(ActivatedRoute);
     fixture.detectChanges();
   });
@@ -47,7 +52,7 @@ describe('HomePage', () => {
   });
 
   it('should navigate based on queryParams on init', async () => {
-    const navigateSpy = spyOn(router, 'navigate');
+    const navigateSpy = spyOn(mockRouter, 'navigate');
 
     (route.queryParams as BehaviorSubject<any>).next({ credential_offer_uri: 'newUri' });
 
@@ -57,10 +62,19 @@ describe('HomePage', () => {
     expect(navigateSpy).toHaveBeenCalledWith(['/tabs/credentials'], { queryParams: { credentialOfferUri: 'newUri' } });
   });
 
-
-  it('startScan should navigate with specific queryParams', () => {
-    const navigateSpy = spyOn(router, 'navigate');
-    component.startScan();
+  it('startScan should navigate with specific queryParams', async () => {
+    const navigateSpy = spyOn(mockRouter, 'navigate');
+    await component.startScan();
     expect(navigateSpy).toHaveBeenCalledWith(['/tabs/credentials/'], { queryParams: { toggleScan: true, from: 'home', show_qr: true } });
   });
+
+  // it('startScan should navigate with specific queryParams', fakeAsync(() => {
+  //   const navigateSpy = spyOn(mockRouter, 'navigate');
+  //   component.startScan();
+  //   tick();
+  //   expect(navigateSpy).toHaveBeenCalledWith(['/tabs/credentials/'], { queryParams: { toggleScan: true, from: 'home', show_qr: true } });
+  // }));
+  
+  
+
 });

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -30,10 +30,8 @@ export class HomePage implements OnInit {
 
   public async startScan() {
     try{
-      console.log('abans await')
       const stream = await navigator.mediaDevices.getUserMedia({ video: true });
       stream.getTracks().forEach(track => track.stop());
-     console.log('despres await')
       this.router.navigate(['/tabs/credentials/'], {
         queryParams: { toggleScan: true, from: 'home', show_qr: true },
       });
@@ -41,7 +39,6 @@ export class HomePage implements OnInit {
     }catch(err){
       alert('Error: ' + err);
     }
-    console.log('fi startScan')
   }
   public handleButtonKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter' || event.key === ' ') {

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -29,9 +29,19 @@ export class HomePage implements OnInit {
   public constructor(private router: Router, private route: ActivatedRoute) { }
 
   public async startScan() {
-    this.router.navigate(['/tabs/credentials/'], {
-      queryParams: { toggleScan: true, from: 'home', show_qr: true },
-    });
+    try{
+      console.log('abans await')
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      stream.getTracks().forEach(track => track.stop());
+     console.log('despres await')
+      this.router.navigate(['/tabs/credentials/'], {
+        queryParams: { toggleScan: true, from: 'home', show_qr: true },
+      });
+      return undefined;
+    }catch(err){
+      alert('Error: ' + err);
+    }
+    console.log('fi startScan')
   }
   public handleButtonKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter' || event.key === ' ') {

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -35,7 +35,6 @@ export class HomePage implements OnInit {
       this.router.navigate(['/tabs/credentials/'], {
         queryParams: { toggleScan: true, from: 'home', show_qr: true },
       });
-      return undefined;
     }catch(err){
       alert('Error: ' + err);
     }


### PR DESCRIPTION
-Fixed bug: after the first activation and following deactivation, the scanner was not being (re)activated from Home. Ionic tabs are not destroyed after exit, so the scanner component was not destroyed, but was configured to reset (deactivate camera), so then it wasn't able to reactivate. This wasn't happening when accessing the scanner repeatedly from credentials page, since in this process scanner was automatically destroyed and reactivated.
-Fix: destroy component on leaving the route associated to the tab page. Also, a function was added to home page to make sure camera is deactivated before starting scan.
