### PR TITLE
Feature/select camera default

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,32 +16,31 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: "./coverage/app",
   coverageReporters: ["lcov", "text-summary", "cobertura", "html"],
-  // collectCoverageFrom: [
-  //   "src/app/components/barcode-scanner/**/*.ts",         
-  //   "src/app/guards/**/*.ts",                  
-  //   "src/app/pages/credentials/**/*.ts",       
-  //   "src/app/pages/settings/**/*.ts",          
-  //   "src/app/pages/logs/**/*.ts",               
-  //   "src/app/services/camera-logs.service.ts"
-  // ],
-  // coveragePathIgnorePatterns: [
-  //   '<rootDir>/node_modules/', 
-  //   '<rootDir>/dist/',
-  //   '<rootDir>/src/app/components/(?!barcode-scanner)',
-  //   '<rootDir>/src/app/interceptors',
-  //   '<rootDir>/src/app/interfaces',
-  //   '<rootDir>/src/app/pages/(?!settings|logs|credentials)',
-  //   '<rootDir>/src/app/services/(?!camera-logs)'
-  // ],
+  collectCoverageFrom: [
+    "src/app/components/barcode-scanner/**/*.ts",         
+    "src/app/guards/**/*.ts",                  
+    "src/app/pages/credentials/**/*.ts",       
+    "src/app/pages/settings/**/*.ts",          
+    "src/app/pages/logs/**/*.ts",               
+    "src/app/services/camera-logs.service.ts"
+  ],
+  coveragePathIgnorePatterns: [
+    '<rootDir>/node_modules/', 
+    '<rootDir>/dist/',
+    '<rootDir>/src/app/components/(?!barcode-scanner)',
+    '<rootDir>/src/app/interceptors',
+    '<rootDir>/src/app/interfaces',
+    '<rootDir>/src/app/pages/(?!settings|logs|credentials|camera-selector)',
+    '<rootDir>/src/app/services/(?!camera-logs|camera.service)'
+  ],
   transformIgnorePatterns: ['/node_modules/(?!@stencil|stencil)/'],
   testPathIgnorePatterns: [
     '/node_modules/', 
     '/dist/',
-    'src/app/guards',
-    '/src/app/components/',
+    '/src/app/components/(?!barcode-scanner)',
     '/src/app/interceptors',
     '/src/app/interfaces',
-    '/src/app/pages/',
-    '/src/app/services/(?!camera.service)'
+    '/src/app/pages/(?!settings|logs|credentials|camera-selector)',
+    '/src/app/services/(?!camera.service|camera-logs)'
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,31 +16,32 @@ module.exports = {
   collectCoverage: true,
   coverageDirectory: "./coverage/app",
   coverageReporters: ["lcov", "text-summary", "cobertura", "html"],
-  collectCoverageFrom: [
-    "src/app/components/barcode-scanner/**/*.ts",         
-    "src/app/guards/**/*.ts",                  
-    "src/app/pages/credentials/**/*.ts",       
-    "src/app/pages/settings/**/*.ts",          
-    "src/app/pages/logs/**/*.ts",               
-    "src/app/services/camera-logs.service.ts"
-  ],
-  coveragePathIgnorePatterns: [
-    '<rootDir>/node_modules/', 
-    '<rootDir>/dist/',
-    '<rootDir>/src/app/components/(?!barcode-scanner)',
-    '<rootDir>/src/app/interceptors',
-    '<rootDir>/src/app/interfaces',
-    '<rootDir>/src/app/pages/(?!settings|logs|credentials)',
-    '<rootDir>/src/app/services/(?!camera-logs)'
-  ],
+  // collectCoverageFrom: [
+  //   "src/app/components/barcode-scanner/**/*.ts",         
+  //   "src/app/guards/**/*.ts",                  
+  //   "src/app/pages/credentials/**/*.ts",       
+  //   "src/app/pages/settings/**/*.ts",          
+  //   "src/app/pages/logs/**/*.ts",               
+  //   "src/app/services/camera-logs.service.ts"
+  // ],
+  // coveragePathIgnorePatterns: [
+  //   '<rootDir>/node_modules/', 
+  //   '<rootDir>/dist/',
+  //   '<rootDir>/src/app/components/(?!barcode-scanner)',
+  //   '<rootDir>/src/app/interceptors',
+  //   '<rootDir>/src/app/interfaces',
+  //   '<rootDir>/src/app/pages/(?!settings|logs|credentials)',
+  //   '<rootDir>/src/app/services/(?!camera-logs)'
+  // ],
   transformIgnorePatterns: ['/node_modules/(?!@stencil|stencil)/'],
   testPathIgnorePatterns: [
     '/node_modules/', 
     '/dist/',
-    '/src/app/components/(?!barcode-scanner)',
+    'src/app/guards',
+    '/src/app/components/',
     '/src/app/interceptors',
     '/src/app/interfaces',
-    '/src/app/pages/(?!settings|logs|credentials)',
-    '/src/app/services/(?!camera-logs)'
+    '/src/app/pages/',
+    '/src/app/services/(?!camera.service)'
   ]
 };

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -3,7 +3,7 @@
     #scanner
     class="scanner"
     [autostart]="true"
-    [device]="newSelectedCamera"
+    [device]="(selectedDevice$|async) ?? undefined"
     [formats]="allowedFormats"
     (camerasFound)="onCamerasFound($event)"
     (scanSuccess)="onCodeResult($event)"

--- a/src/app/components/barcode-scanner/barcode-scanner.component.html
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.html
@@ -1,12 +1,12 @@
-
-<zxing-scanner
-    #scanner
-    class="scanner"
-    [autostart]="true"
-    [device]="(selectedDevice$|async) ?? undefined"
-    [formats]="allowedFormats"
-    (camerasFound)="onCamerasFound($event)"
-    (scanSuccess)="onCodeResult($event)"
-    (scanError)="onScanError($event)" 
-    (scanFailure)="onScanFailure($event)"
+    <zxing-scanner
+        #scanner
+        class="scanner"
+        [autostart]="true"
+        [device]="(selectedDevice$|async) ?? undefined"
+        [formats]="allowedFormats"
+        (autostarted)="onAutostarted()"
+        (camerasFound)="onCamerasFound($event)"
+        (scanSuccess)="onCodeResult($event)"
+        (scanError)="onScanError($event)" 
+        (scanFailure)="onScanFailure($event)"
     ></zxing-scanner>

--- a/src/app/components/barcode-scanner/barcode-scanner.component.spec.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.spec.ts
@@ -2,13 +2,13 @@ import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testin
 import { CommonModule } from '@angular/common';
 import { ZXingScannerModule } from '@zxing/ngx-scanner';
 import { CameraService } from 'src/app/services/camera.service';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { BarcodeScannerComponent, formatLogMessage } from './barcode-scanner.component';
 import { CameraLogsService } from 'src/app/services/camera-logs.service';
 import { Storage } from '@ionic/storage-angular';
 import { Exception } from '@zxing/library';
 import { CameraLogType } from 'src/app/interfaces/camera-log';
-import { NavigationEnd, Router } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 
 class MockCameraService {
   updateCamera(): void {}
@@ -25,6 +25,7 @@ describe('BarcodeScannerComponent', () => {
   let mockCameraService: MockCameraService;
   let mockCameraLogsService: CameraLogsService;
   let mockRouter: MockRouter;
+  let mockActivatedRoute: {};
 
   beforeEach(async () => {
     mockCameraService = new MockCameraService();
@@ -32,6 +33,11 @@ describe('BarcodeScannerComponent', () => {
       addCameraLog: jest.fn()
     } as any;
     mockRouter = new MockRouter();
+    mockActivatedRoute = {
+      snapshot: {
+        url: [{path:'camera-selector'}]
+      }
+    };
 
     await TestBed.configureTestingModule({
       imports: [CommonModule, ZXingScannerModule],
@@ -39,6 +45,10 @@ describe('BarcodeScannerComponent', () => {
         { provide: CameraService, useClass: MockCameraService }, 
         { provide: CameraLogsService, useValue:mockCameraLogsService },
         { provide: Router, useValue: mockRouter },
+        {
+          provide: ActivatedRoute,
+          useValue:mockActivatedRoute,
+        },
         Storage
       ]
     }).compileComponents();
@@ -164,12 +174,27 @@ describe('BarcodeScannerComponent', () => {
     expect(console.error).toBe(console.error);
   });
 
-  it('should reset scanner on NavigationEnd', fakeAsync(() => {
+  it('should reset scanner on NavigationEnd if origin route is "camera-selector"', fakeAsync(() => {
     jest.spyOn(component.scanner, 'reset'); 
     mockRouter.events.next(new NavigationEnd(1, 'http://localhost/', 'http://localhost/'));
     tick();
     expect(component.scanner.reset).toHaveBeenCalled();
   }));
+  it('should reset scanner on NavigationEnd if origin route is "credentials"', fakeAsync(() => {
+    (mockActivatedRoute as any).snapshot.url = [{path:'credentials'}];
+    jest.spyOn(component.scanner, 'reset'); 
+    mockRouter.events.next(new NavigationEnd(1, 'http://localhost/', 'http://localhost/'));
+    tick();
+    expect(component.scanner.reset).toHaveBeenCalled();
+  }));
+
+  it('should not reset scanner on NavigationEnd if origin route is not "camera-selector" nor "credentials"', fakeAsync(() => {
+    (mockActivatedRoute as any).snapshot.url = [{path:'other'}];
+    jest.spyOn(component.scanner, 'reset'); 
+    mockRouter.events.next(new NavigationEnd(1, 'http://localhost/', 'http://localhost/'));
+    tick();
+    expect(component.scanner.reset).not.toHaveBeenCalled();
+}));
 });
 
 describe('formatLogMessage', () => {

--- a/src/app/components/barcode-scanner/barcode-scanner.component.spec.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.spec.ts
@@ -97,23 +97,24 @@ describe('BarcodeScannerComponent', () => {
     expect(component.availableDevices.emit).toHaveBeenCalledWith(testDevices as MediaDeviceInfo[]);
   });
 
-  it('should select the back camera by default in onCamerasFound', () => {
-    const testDevices = [
-      { deviceId: '1', kind: 'videoinput', label: 'Front Camera', groupId: 'group1', toJSON: () => {} },
-      { deviceId: '2', kind: 'videoinput', label: 'Back Camera', groupId: 'group2', toJSON: () => {} }
-    ];
-    component.onCamerasFound(testDevices as MediaDeviceInfo[]);
-    expect(component.newSelectedCamera.deviceId).toBe('2');
-  });
+   //TODO TESTS FOR NEW AVAILABLE AND SELECTED CAMERA FLOW
+  // it('should select the back camera by default in onCamerasFound', () => {
+  //   const testDevices = [
+  //     { deviceId: '1', kind: 'videoinput', label: 'Front Camera', groupId: 'group1', toJSON: () => {} },
+  //     { deviceId: '2', kind: 'videoinput', label: 'Back Camera', groupId: 'group2', toJSON: () => {} }
+  //   ];
+  //   component.onCamerasFound(testDevices as MediaDeviceInfo[]);
+  //   expect(component.newSelectedCamera.deviceId).toBe('2');
+  // });
 
-  it('should select the first camera if no back camera is found in onCamerasFound', () => {
-    const testDevices = [
-      { deviceId: '1', kind: 'videoinput', label: 'Front Camera 1', groupId: 'group1', toJSON: () => {} },
-      { deviceId: '2', kind: 'videoinput', label: 'Front Camera 2', groupId: 'group2', toJSON: () => {} }
-    ];
-    component.onCamerasFound(testDevices as MediaDeviceInfo[]);
-    expect(component.newSelectedCamera.deviceId).toBe('2');
-  });
+  // it('should select the first camera if no back camera is found in onCamerasFound', () => {
+  //   const testDevices = [
+  //     { deviceId: '1', kind: 'videoinput', label: 'Front Camera 1', groupId: 'group1', toJSON: () => {} },
+  //     { deviceId: '2', kind: 'videoinput', label: 'Front Camera 2', groupId: 'group2', toJSON: () => {} }
+  //   ];
+  //   component.onCamerasFound(testDevices as MediaDeviceInfo[]);
+  //   expect(component.newSelectedCamera.deviceId).toBe('2');
+  // });
 
   it('should toggleCamera$ when navCamera$ emits a device with deviceId', fakeAsync(() => {
     const testDevice = { deviceId: '1', kind: 'videoinput', label: 'Camera 1', groupId: 'group1', toJSON: () => {} };

--- a/src/app/components/barcode-scanner/barcode-scanner.component.ts
+++ b/src/app/components/barcode-scanner/barcode-scanner.component.ts
@@ -39,25 +39,12 @@ export class BarcodeScannerComponent implements OnInit {
     new EventEmitter();
   @Output() public qrCode: EventEmitter<string> = new EventEmitter();
   @ViewChild('scanner') public scanner!: ZXingScannerComponent;
-  public newSelectedCamera!: MediaDeviceInfo;
   public allowedFormats = [BarcodeFormat.QR_CODE];
 
   public devices$ = new BehaviorSubject<MediaDeviceInfo[]>([]);
 
-  public toggleCamera$ = new BehaviorSubject<boolean>(false);
-  public enable$ = this.toggleCamera$.pipe(
-    map((value) => {
-      return value;
-    }),
-    distinctUntilChanged(),
-    shareReplay(1)
-  );
   public selectedDevice$: Observable<MediaDeviceInfo> =
     this.cameraService.navCamera$.pipe(
-      map((device) => {
-        this.toggleCamera$.next(device.deviceId != '');
-        return device;
-      }),
       distinctUntilChanged(),
       shareReplay(1)
     );
@@ -125,20 +112,7 @@ export class BarcodeScannerComponent implements OnInit {
   }
 
   public async onCamerasFound(devices: MediaDeviceInfo[]): Promise<void> {
-    const selectedDevices: MediaDeviceInfo[] = [];
-    for (const device of devices) {
-      if (/back|rear|environment/gi.test(device.label)) {
-        selectedDevices.push(device);
-        break;
-      }
-    }
-    if (selectedDevices.length === 0) {
-      this.newSelectedCamera = devices[1] || devices[0];
-    } else {
-      this.newSelectedCamera = selectedDevices[0];
-    }
-
-    this.availableDevices.emit(devices);
+     this.availableDevices.emit(devices);
   }
 
   public onScanError(error: Error){

--- a/src/app/pages/camera-selector/camera-selector.page.html
+++ b/src/app/pages/camera-selector/camera-selector.page.html
@@ -3,20 +3,22 @@
     <b class="pages_titles">{{"camera-selector.settings" | translate}}</b>
     <p class="camera-selector-title">{{"camera-selector.title" | translate}}</p>
     <ion-row class="ion-justify-content-start" class="camera-row">
-      <ion-select [ngModel]="selectedDevice | async" (ionChange)="onDeviceSelectChange($any($event).target?.value)" interface="popover" class="camera-select">
+      <ion-select [ngModel]="selectedDevice$ | async" (ionChange)="onDeviceSelectChange($any($event).target?.value)" interface="popover" class="camera-select">
         <ion-select-option value="">No Device</ion-select-option>
+        <ion-select-option *ngIf="(selectedDevice$ | async) === 'Default'" value="Default">Default Device</ion-select-option>
         <ion-select-option *ngFor="let camera of availableDevices" [value]="camera.deviceId">
-          {{ camera.label }}
+          {{ camera.label}}
         </ion-select-option>
       </ion-select>
     </ion-row>
 
-    
-    <ion-row class="ion-justify-content-center">
-      <app-barcode-scanner
-        (availableDevices)="availableDevicesEmit($event)"
-      ></app-barcode-scanner>
-    </ion-row>
+    @if(showBarcode){
+      <ion-row class="ion-justify-content-center">
+        <app-barcode-scanner
+          (availableDevices)="availableDevicesEmit($event)"
+        ></app-barcode-scanner>
+      </ion-row>
+    }
   </ion-grid>
 
 </ion-content>

--- a/src/app/pages/camera-selector/camera-selector.page.spec.ts
+++ b/src/app/pages/camera-selector/camera-selector.page.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { CameraSelectorPage } from './camera-selector.page';
+import { CameraService } from 'src/app/services/camera.service';
+import { CameraLogsService } from 'src/app/services/camera-logs.service';
+import { Router, NavigationEnd, ActivatedRoute } from '@angular/router';
+import { ChangeDetectorRef } from '@angular/core';
+import { BehaviorSubject, of } from 'rxjs';
+import { IonicModule } from '@ionic/angular';
+import { TranslateModule } from '@ngx-translate/core';
+
+describe('CameraSelectorPage', () => {
+  let component: CameraSelectorPage;
+  let fixture: ComponentFixture<CameraSelectorPage>;
+  let cameraServiceMock: any;
+  let routerMock: any;
+  let cdrMock: any;
+  let storageMock: any;
+  let cameraLogsServiceMock: any;
+  let activatedRouteMock: any;
+
+  beforeEach(async () => {
+    cameraServiceMock = {
+      navCamera$: new BehaviorSubject({ deviceId: '123' }),
+      changeCamera: jest.fn(),
+      noCamera: jest.fn(),
+    };
+
+    routerMock = {
+      events: new BehaviorSubject<NavigationEnd | null>(null),
+      navigate: jest.fn(),
+    };
+
+    cdrMock = {
+      detectChanges: jest.fn(),
+    };
+
+    cameraLogsServiceMock = {
+        log: jest.fn(),
+      };
+
+    storageMock = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+
+    activatedRouteMock = {
+        snapshot: { paramMap: { get: jest.fn() } }
+      }
+
+    await TestBed.configureTestingModule({
+      imports: [
+        CameraSelectorPage,
+        IonicModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        { provide: CameraService, useValue: cameraServiceMock },
+        { provide: CameraLogsService, useValue: cameraLogsServiceMock }, 
+        { provide: Router, useValue: routerMock },
+        { provide: ChangeDetectorRef, useValue: cdrMock },
+        { provide: Storage, useValue: storageMock },
+        { provide: ActivatedRoute, useValue: activatedRouteMock}
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CameraSelectorPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should set the default selected device to "Default"', () => {
+    component.selectedDevice$.subscribe((deviceId) => {
+      expect(deviceId).toBe('123');
+    });
+  });
+
+  it('should call changeCamera when onDeviceSelectChange is called with a valid device', () => {
+    const mockDevice = { deviceId: '123', label: 'Mock Device' } as MediaDeviceInfo;
+    component.availableDevices = [mockDevice];
+    
+    component.onDeviceSelectChange('123');
+    expect(cameraServiceMock.changeCamera).toHaveBeenCalledWith(mockDevice);
+  });
+
+  it('should call noCamera when onDeviceSelectChange is called with an empty string', () => {
+    component.onDeviceSelectChange('');
+    expect(cameraServiceMock.noCamera).toHaveBeenCalled();
+  });
+
+  it('should prioritize rear cameras when availableDevicesEmit is called', () => {
+    const devices: MediaDeviceInfo[] = [
+      { deviceId: '123', label: 'Front Camera' } as MediaDeviceInfo,
+      { deviceId: '456', label: 'Back Camera' } as MediaDeviceInfo,
+    ];
+    component.availableDevicesEmit(devices);
+    expect(component.availableDevices.length).toBe(1);
+    expect(component.availableDevices[0].deviceId).toBe('456'); 
+  });
+
+
+  it('should listen to router events and reset barcode if conditions match', () => {
+    (component as any).componentIsInitialized = true;
+    const spy = jest.spyOn(component, 'resetBarcode');
+    routerMock.events.next(new NavigationEnd(1, '/tabs/camera-selector', '/tabs/camera-selector'));
+    expect(spy).toHaveBeenCalled();
+  });
+});

--- a/src/app/pages/camera-selector/camera-selector.page.ts
+++ b/src/app/pages/camera-selector/camera-selector.page.ts
@@ -18,7 +18,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     CommonModule,
     FormsModule,
     TranslateModule,
-    BarcodeScannerComponent,
+    BarcodeScannerComponent
   ],
 })
 // eslint-disable-next-line @angular-eslint/component-class-suffix

--- a/src/app/pages/camera-selector/camera-selector.page.ts
+++ b/src/app/pages/camera-selector/camera-selector.page.ts
@@ -35,21 +35,12 @@ export class CameraSelectorPage {
   public availableDevicesEmit(devices: MediaDeviceInfo[]) {
     if (devices.length <= 1) {
       this.availableDevices = devices;
-    } else {
-      //selects the devices's back camera by default
-      const selectedDevices: MediaDeviceInfo[] = [];
-      for (const device of devices) {
-        if (/back|rear|environment/gi.test(device.label)) {
-          selectedDevices.push(device);
-          break;
-        }
-      }
-      if (selectedDevices.length === 0) {
-        this.availableDevices = devices;
-      } else {
-        this.availableDevices = selectedDevices;
-      }
+      return;
     }
+    
+    //prioritize rear cameras
+    const selectedDevices = devices.filter(device => /back|rear|environment/gi.test(device.label));
+    this.availableDevices = selectedDevices.length > 0 ? selectedDevices : devices;
   }
 
   public onDeviceSelectChange(selected: string) {

--- a/src/app/pages/camera-selector/camera-selector.page.ts
+++ b/src/app/pages/camera-selector/camera-selector.page.ts
@@ -1,11 +1,13 @@
-import { Component, Input, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 import { BarcodeScannerComponent } from '../../components/barcode-scanner/barcode-scanner.component';
 import { CameraService } from 'src/app/services/camera.service';
 import { TranslateModule } from '@ngx-translate/core';
-import { distinctUntilChanged, map, shareReplay } from 'rxjs';
+import { distinctUntilChanged, filter, map, shareReplay, tap } from 'rxjs';
+import { NavigationEnd, Router } from '@angular/router';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 @Component({
   selector: 'app-camera-selector',
   templateUrl: './camera-selector.page.html',
@@ -23,14 +25,43 @@ import { distinctUntilChanged, map, shareReplay } from 'rxjs';
 export class CameraSelectorPage {
   @Input() public availableDevices: MediaDeviceInfo[] = [];
   public cameraService = inject(CameraService);
+  private router = inject(Router);
+  private cdr = inject(ChangeDetectorRef);
 
-  public selectedDevice = this.cameraService.navCamera$.pipe(
+  public showBarcode = true;
+  private componentIsInitialized = false;
+
+  public selectedDevice$ = this.cameraService.navCamera$.pipe(
     map((device) => {
-      return device.deviceId;
+      return device?.deviceId ?? 'Default';
     }),
     distinctUntilChanged(),
     shareReplay(1)
   );
+
+  constructor(){
+    this.router.events
+    .pipe(
+      filter(event => event instanceof NavigationEnd),
+      takeUntilDestroyed()
+    )
+    .subscribe((event: NavigationEnd) => {
+      if (this.componentIsInitialized &&
+        event.urlAfterRedirects.startsWith('/tabs/camera-selector')) {
+       this.resetBarcode();
+      }else{
+        this.componentIsInitialized = true;
+      }
+    });
+  }
+
+  public resetBarcode(){
+    console.log('reset barcode from selector')
+    this.showBarcode = false;
+    this.cdr.detectChanges();
+    this.showBarcode = true;
+  }
+  
 
   public availableDevicesEmit(devices: MediaDeviceInfo[]) {
     if (devices.length <= 1) {

--- a/src/app/services/camera.service.ts
+++ b/src/app/services/camera.service.ts
@@ -7,6 +7,7 @@ import { StorageService } from './storage.service';
 })
 export class CameraService {
   public mediaDeviceInfoNull: MediaDeviceInfo|undefined = undefined;
+  //TODO camera?
   public camara = new BehaviorSubject<MediaDeviceInfo|undefined>(
     this.mediaDeviceInfoNull
   );

--- a/src/app/services/camera.service.ts
+++ b/src/app/services/camera.service.ts
@@ -1,23 +1,20 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, distinctUntilChanged, shareReplay, tap } from 'rxjs';
 import { StorageService } from './storage.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class CameraService {
-  public mediaDeviceInfoNull: MediaDeviceInfo = {
-    deviceId: '',
-    groupId: '',
-    kind: 'audiooutput',
-    label: '',
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    toJSON() {},
-  };
-  public camara = new BehaviorSubject<MediaDeviceInfo>(
+  public mediaDeviceInfoNull: MediaDeviceInfo|undefined = undefined;
+  public camara = new BehaviorSubject<MediaDeviceInfo|undefined>(
     this.mediaDeviceInfoNull
   );
-  public navCamera$ = this.camara.asObservable();
+  //TODO remove tap
+  public navCamera$ = this.camara.asObservable().pipe(
+    distinctUntilChanged(),
+    shareReplay(1),
+    );
 
   public constructor(private storageService: StorageService) {
     this.updateCamera();
@@ -28,17 +25,46 @@ export class CameraService {
     this.storageService.set('camara', camara);
   }
 
-  public updateCamera() {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.storageService.get('camara').then((result: any) => {
-      if (result != null) {
+  //TODO when stored camera is not valid, should components know (camera-selector.page selector for ex.)?
+  public async updateCamera() {
+    const result = await this.storageService.get('camara');
+    console.log('Camera from storage:' + result);
+
+    if (result != null && this.isValidMediaDeviceInfo(result)) {
+      const isAvailable = await this.isCameraAvailable(result);
+      
+      if (isAvailable) {
         this.camara.next(result);
+      } else {
+        console.warn('Stored camera not available');
+        this.noCamera();
       }
-    });
+    } else {
+      console.error('Stored camera is not valid or null');
+      this.noCamera();
+    }
   }
 
   public noCamera() {
     this.storageService.remove('camara');
     this.camara.next(this.mediaDeviceInfoNull);
+  }
+
+  public async isCameraAvailable(camera: MediaDeviceInfo): Promise<boolean> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const availableCamera = devices.find(
+      (device) => device.deviceId === camera.deviceId && device.kind === 'videoinput'
+    );
+    return !!availableCamera;
+  }
+
+  private isValidMediaDeviceInfo(object: any): object is MediaDeviceInfo {
+    return (
+      object &&
+      typeof object.deviceId === 'string' &&
+      typeof object.label === 'string' &&
+      typeof object.kind === 'string' &&
+      object.kind === 'videoinput'
+    );
   }
 }


### PR DESCRIPTION
Camera service, Camera selector and Barcode have been refactored so that

1. all available cameras are shown when selecting camera (camera selector)
2. the selected camera is actually used by the scanner (barcode)
3. if the stored camera is not available, the error is handled and the selector shows 'Default Device' (the scanner uses automatically the first available device) (camera service & camera selector)
4. Also the reset of the scanner is enhanced so that it only occurs when a page with the scanner is left (barcode and camera selector)